### PR TITLE
feat(repl): add configurable completion menu size

### DIFF
--- a/docs/sdk/01-gsh-object.md
+++ b/docs/sdk/01-gsh-object.md
@@ -93,6 +93,7 @@ Controls tab-completion menu behavior.
 | -------------------------------- | --------------------- | -------------------------------------------------------- |
 | `gsh.completion.maxVisibleItems` | `number` (read/write) | Number of completion suggestions shown at once           |
 
+The value must be an integer of at least `1`.
 The default is `10`.
 Set this in `~/.gsh/repl.gsh` to show more or fewer completion options before the menu scrolls.
 

--- a/docs/sdk/01-gsh-object.md
+++ b/docs/sdk/01-gsh-object.md
@@ -43,7 +43,7 @@ Use terminal dimensions to format output appropriately for the user's screen siz
 
 ## `gsh.logging`
 
-**Type:** `object`  
+**Type:** `object`
 **Availability:** REPL + Script
 
 Controls logging behavior.
@@ -78,6 +78,29 @@ View logs with:
 
 ```bash
 tail -f ~/.gsh/gsh.log
+```
+
+## `gsh.completion`
+
+**Type:** `object`
+**Availability:** REPL + Script
+
+Controls tab-completion menu behavior.
+
+### Properties
+
+| Property                         | Type                  | Description                                              |
+| -------------------------------- | --------------------- | -------------------------------------------------------- |
+| `gsh.completion.maxVisibleItems` | `number` (read/write) | Number of completion suggestions shown at once           |
+
+The default is `10`.
+Set this in `~/.gsh/repl.gsh` to show more or fewer completion options before the menu scrolls.
+
+### Example
+
+```gsh
+# Show up to 20 tab-completion options at once
+gsh.completion.maxVisibleItems = 20
 ```
 
 ## `gsh.prompt`

--- a/docs/sdk/01-gsh-object.md
+++ b/docs/sdk/01-gsh-object.md
@@ -93,7 +93,7 @@ Controls tab-completion menu behavior.
 | -------------------------------- | --------------------- | -------------------------------------------------------- |
 | `gsh.completion.maxVisibleItems` | `number` (read/write) | Number of completion suggestions shown at once           |
 
-The value must be an integer of at least `1`.
+The value must be an integer from `1` through the maximum supported Go `int` value.
 The default is `10`.
 Set this in `~/.gsh/repl.gsh` to show more or fewer completion options before the menu scrolls.
 

--- a/docs/sdk/README.md
+++ b/docs/sdk/README.md
@@ -10,6 +10,7 @@ The `gsh` object is the primary API for configuring and extending gsh, available
 | `gsh.version`                | Current gsh version                          | REPL + Script |
 | `gsh.terminal`               | Terminal dimensions and TTY info             | REPL + Script |
 | `gsh.logging`                | Log level and file configuration             | REPL + Script |
+| `gsh.completion`             | Tab-completion menu configuration            | REPL + Script |
 | `gsh.models`                 | Model tier system (lite, workhorse, premium) | REPL + Script |
 | `gsh.tools`                  | Built-in tools for agents                    | REPL + Script |
 | `gsh.prompt`                 | Set the shell prompt                         | REPL only     |
@@ -35,13 +36,16 @@ gsh.models.workhorse = myModel
 
 # Set logging level
 gsh.logging.level = "info"
+
+# Show more tab-completion options at once
+gsh.completion.maxVisibleItems = 20
 ```
 
 You can study the default configuration in `cmd/gsh/defaults/` as a reference.
 
 ## Chapters
 
-1. **[Core Properties](01-gsh-object.md)** - Version, terminal, logging, prompt, lastCommand
+1. **[Core Properties](01-gsh-object.md)** - Version, terminal, logging, completion, prompt, lastCommand
 2. **[Models](02-models.md)** - Model tiers and model declaration syntax
 3. **[Tools](03-tools.md)** - Built-in tools for agents (exec, grep, view_file, edit_file)
 4. **[Agents](04-agents.md)** - Defining and using custom agents

--- a/internal/evaluate/similarity.go
+++ b/internal/evaluate/similarity.go
@@ -197,7 +197,7 @@ func nodeLabel(n syntax.Node) string {
 		return "nil"
 	}
 	t := reflect.TypeOf(n)
-	if t.Kind() == reflect.Ptr {
+	if t.Kind() == reflect.Pointer {
 		t = t.Elem()
 	}
 	label := t.Name()
@@ -220,7 +220,7 @@ func getChildren(n syntax.Node) []syntax.Node {
 	var children []syntax.Node
 	v := reflect.ValueOf(n)
 	// If it's a pointer, get the element.
-	if v.Kind() == reflect.Ptr {
+	if v.Kind() == reflect.Pointer {
 		v = v.Elem()
 	}
 	// Only process structs.
@@ -249,7 +249,7 @@ func getChildren(n syntax.Node) []syntax.Node {
 			}
 		}
 		// Also check for pointer fields that may hold a syntax.Node.
-		if field.Kind() == reflect.Ptr && !field.IsNil() {
+		if field.Kind() == reflect.Pointer && !field.IsNil() {
 			if child, ok := field.Interface().(syntax.Node); ok && child != nil {
 				children = append(children, child)
 			}

--- a/internal/repl/input/input.go
+++ b/internal/repl/input/input.go
@@ -113,6 +113,10 @@ type Config struct {
 	// CompletionProvider provides tab completion suggestions.
 	CompletionProvider CompletionProvider
 
+	// CompletionMaxVisible is the maximum number of completion suggestions shown at once.
+	// If zero or negative, a default is used.
+	CompletionMaxVisible int
+
 	// PredictionState manages command predictions.
 	PredictionState *PredictionState
 
@@ -167,6 +171,7 @@ func New(cfg Config) Model {
 	renderer := NewRenderer(*renderConfig, NewHighlighter(cfg.AliasExistsFunc, cfg.GetEnvFunc, cfg.GetWorkingDirFunc))
 	renderer.SetWidth(width)
 	renderer.SetContinuationPrompt(continuationPrompt)
+	renderer.SetCompletionMaxVisible(cfg.CompletionMaxVisible)
 
 	return Model{
 		buffer:             NewBuffer(),

--- a/internal/repl/input/input_test.go
+++ b/internal/repl/input/input_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	tea "github.com/charmbracelet/bubbletea"
+	"github.com/charmbracelet/x/ansi"
 )
 
 // mockCompletionProvider implements CompletionProvider for testing.
@@ -484,6 +485,7 @@ func TestCompletionMenuUsesConfiguredVisibleItemCount(t *testing.T) {
 	if strings.Contains(view, "item07") {
 		t.Fatalf("expected configured completion menu to stop before the seventh item, got:\n%s", view)
 	}
+	t.Logf("rendered completion menu with CompletionMaxVisible=6:\n%s", ansi.Strip(view))
 }
 
 func TestSingleCompletion(t *testing.T) {

--- a/internal/repl/input/input_test.go
+++ b/internal/repl/input/input_test.go
@@ -1,6 +1,7 @@
 package input
 
 import (
+	"strings"
 	"testing"
 
 	tea "github.com/charmbracelet/bubbletea"
@@ -438,6 +439,50 @@ func TestCompletion(t *testing.T) {
 
 	if m.Value() != "file2.txt" {
 		t.Errorf("expected 'file2.txt', got '%s'", m.Value())
+	}
+}
+
+func TestCompletionMenuShowsMoreThanFourItemsByDefault(t *testing.T) {
+	provider := &mockCompletionProvider{
+		completions: []string{"item01", "item02", "item03", "item04", "item05", "item06"},
+	}
+
+	m := New(Config{
+		Prompt:             "> ",
+		CompletionProvider: provider,
+	})
+	m.SetValue("item")
+
+	newModel, _ := m.Update(tea.KeyMsg{Type: tea.KeyTab})
+	m = newModel.(Model)
+
+	view := m.View()
+	if !strings.Contains(view, "item05") {
+		t.Fatalf("expected default completion menu to include the fifth item, got:\n%s", view)
+	}
+}
+
+func TestCompletionMenuUsesConfiguredVisibleItemCount(t *testing.T) {
+	provider := &mockCompletionProvider{
+		completions: []string{"item01", "item02", "item03", "item04", "item05", "item06", "item07", "item08"},
+	}
+
+	m := New(Config{
+		Prompt:               "> ",
+		CompletionProvider:   provider,
+		CompletionMaxVisible: 6,
+	})
+	m.SetValue("item")
+
+	newModel, _ := m.Update(tea.KeyMsg{Type: tea.KeyTab})
+	m = newModel.(Model)
+
+	view := m.View()
+	if !strings.Contains(view, "item06") {
+		t.Fatalf("expected configured completion menu to include the sixth item, got:\n%s", view)
+	}
+	if strings.Contains(view, "item07") {
+		t.Fatalf("expected configured completion menu to stop before the seventh item, got:\n%s", view)
 	}
 }
 

--- a/internal/repl/input/render.go
+++ b/internal/repl/input/render.go
@@ -801,32 +801,27 @@ func CalculateCursorPosition(prompt string, text string, cursorPos int) int {
 
 // calculateVisibleWindow determines the start and end indices for a scrolling window.
 func calculateVisibleWindow(selected, total, maxVisible int) (start, end int) {
+	if total <= 0 || maxVisible <= 0 {
+		return 0, 0
+	}
+	if selected < 0 {
+		selected = 0
+	}
+	if selected >= total {
+		selected = total - 1
+	}
 	if total <= maxVisible {
 		return 0, total
 	}
 
-	// Try to keep selection roughly in the middle
-	if selected < 2 {
-		start = 0
-	} else if selected >= total-2 {
-		start = total - maxVisible
-	} else {
-		start = selected - 1
-	}
-
-	end = start + maxVisible
-
-	// Ensure bounds
+	start = selected - (maxVisible-1)/2
 	if start < 0 {
 		start = 0
 	}
-	if end > total {
-		end = total
-		start = end - maxVisible
-		if start < 0 {
-			start = 0
-		}
+	if start+maxVisible > total {
+		start = total - maxVisible
 	}
+	end = start + maxVisible
 
 	return start, end
 }

--- a/internal/repl/input/render.go
+++ b/internal/repl/input/render.go
@@ -33,6 +33,8 @@ type RenderConfig struct {
 	SelectedStyle lipgloss.Style
 }
 
+const defaultCompletionMaxVisible = 10
+
 // DefaultRenderConfig returns a RenderConfig with sensible default styles.
 func DefaultRenderConfig() RenderConfig {
 	return RenderConfig{
@@ -52,10 +54,11 @@ func DefaultRenderConfig() RenderConfig {
 
 // Renderer handles rendering of input components.
 type Renderer struct {
-	config             RenderConfig
-	width              int
-	highlighter        *Highlighter
-	continuationPrompt string
+	config               RenderConfig
+	width                int
+	highlighter          *Highlighter
+	continuationPrompt   string
+	completionMaxVisible int
 }
 
 // NewRenderer creates a new Renderer with the given configuration.
@@ -65,10 +68,27 @@ func NewRenderer(config RenderConfig, h *Highlighter) *Renderer {
 	}
 
 	return &Renderer{
-		config:      config,
-		width:       80, // default width
-		highlighter: h,
+		config:               config,
+		width:                80, // default width
+		highlighter:          h,
+		completionMaxVisible: defaultCompletionMaxVisible,
 	}
+}
+
+// SetCompletionMaxVisible sets how many completion items are visible at once.
+func (r *Renderer) SetCompletionMaxVisible(maxVisible int) {
+	if maxVisible <= 0 {
+		maxVisible = defaultCompletionMaxVisible
+	}
+	r.completionMaxVisible = maxVisible
+}
+
+// CompletionMaxVisible returns how many completion items are visible at once.
+func (r *Renderer) CompletionMaxVisible() int {
+	if r.completionMaxVisible <= 0 {
+		return defaultCompletionMaxVisible
+	}
+	return r.completionMaxVisible
 }
 
 // SetContinuationPrompt sets the prompt displayed on continuation lines for multi-line input.
@@ -597,7 +617,7 @@ func (r *Renderer) RenderCompletionBox(cs *CompletionState, maxVisible int) stri
 	}
 
 	if maxVisible <= 0 {
-		maxVisible = 4 // default
+		maxVisible = defaultCompletionMaxVisible
 	}
 
 	suggestions := cs.Suggestions()
@@ -732,7 +752,7 @@ func (r *Renderer) RenderFullView(
 	// Render completion box if active
 	if completion != nil && completion.IsVisible() {
 		result.WriteString("\n")
-		result.WriteString(r.RenderCompletionBox(completion, 4))
+		result.WriteString(r.RenderCompletionBox(completion, r.CompletionMaxVisible()))
 	}
 
 	// Render info panel content

--- a/internal/repl/input/render_test.go
+++ b/internal/repl/input/render_test.go
@@ -483,6 +483,14 @@ func TestCalculateVisibleWindow(t *testing.T) {
 			wantStart:  6,
 			wantEnd:    10,
 		},
+		{
+			name:       "single visible item follows selection",
+			selected:   1,
+			total:      10,
+			maxVisible: 1,
+			wantStart:  1,
+			wantEnd:    2,
+		},
 	}
 
 	for _, tt := range tests {

--- a/internal/repl/repl.go
+++ b/internal/repl/repl.go
@@ -318,17 +318,18 @@ func (r *REPL) Run(ctx context.Context) error {
 			termWidth = 80
 		}
 		inputModel := input.New(input.Config{
-			Prompt:             prompt,
-			ContinuationPrompt: r.getContinuationPrompt(),
-			HistoryValues:      historyValues,
-			HistorySearchFunc:  r.createHistorySearchFunc(),
-			CompletionProvider: r.completionProvider,
-			AliasExistsFunc:    r.executor.AliasOrFunctionExists,
-			GetEnvFunc:         r.executor.GetEnv,
-			GetWorkingDirFunc:  r.executor.GetPwd,
-			PredictionState:    predictionState,
-			Width:              termWidth,
-			Logger:             r.logger,
+			Prompt:               prompt,
+			ContinuationPrompt:   r.getContinuationPrompt(),
+			HistoryValues:        historyValues,
+			HistorySearchFunc:    r.createHistorySearchFunc(),
+			CompletionProvider:   r.completionProvider,
+			CompletionMaxVisible: r.executor.Interpreter().SDKConfig().GetCompletionMaxVisibleItems(),
+			AliasExistsFunc:      r.executor.AliasOrFunctionExists,
+			GetEnvFunc:           r.executor.GetEnv,
+			GetWorkingDirFunc:    r.executor.GetPwd,
+			PredictionState:      predictionState,
+			Width:                termWidth,
+			Logger:               r.logger,
 		})
 
 		// Run the input loop

--- a/internal/script/interpreter/builtin_sdk.go
+++ b/internal/script/interpreter/builtin_sdk.go
@@ -20,6 +20,30 @@ func (i *Interpreter) registerGshSDK() {
 	// Create gsh.logging object (read/write)
 	loggingObj := &LoggingObjectValue{interp: i}
 
+	// Create gsh.completion object (read-only object, writable settings)
+	completionObj := &ObjectValue{
+		Properties: map[string]*PropertyDescriptor{
+			"maxVisibleItems": {
+				Getter: func() Value {
+					return &NumberValue{Value: float64(i.sdkConfig.GetCompletionMaxVisibleItems())}
+				},
+				Setter: func(value Value) error {
+					num, ok := value.(*NumberValue)
+					if !ok {
+						return fmt.Errorf("gsh.completion.maxVisibleItems must be a number, got %s", value.Type())
+					}
+					if math.Trunc(num.Value) != num.Value {
+						return fmt.Errorf("gsh.completion.maxVisibleItems must be an integer")
+					}
+					if num.Value > float64(int(^uint(0)>>1)) {
+						return fmt.Errorf("gsh.completion.maxVisibleItems is too large")
+					}
+					return i.sdkConfig.SetCompletionMaxVisibleItems(int(num.Value))
+				},
+			},
+		},
+	}
+
 	// Create gsh.lastAgentRequest object (read-only, but properties updated by system)
 	lastAgentRequestObj := &DynamicValue{
 		Get: func() Value { return i.sdkConfig.GetLastAgentRequest() },
@@ -159,6 +183,7 @@ func (i *Interpreter) registerGshSDK() {
 			"version":            {Value: &StringValue{Value: i.version}, ReadOnly: true},
 			"terminal":           {Value: terminalObj, ReadOnly: true},
 			"logging":            {Value: loggingObj},
+			"completion":         {Value: completionObj, ReadOnly: true},
 			"lastAgentRequest":   {Value: lastAgentRequestObj, ReadOnly: true},
 			"tools":              {Value: toolsObj, ReadOnly: true},
 			"ui":                 {Value: uiObj, ReadOnly: true},

--- a/internal/script/interpreter/builtin_sdk_test.go
+++ b/internal/script/interpreter/builtin_sdk_test.go
@@ -133,6 +133,37 @@ gsh.models.lite = testLite
 	}
 }
 
+func TestGshCompletionMaxVisibleItems(t *testing.T) {
+	interp := New(&Options{})
+	defer interp.Close()
+
+	result, err := interp.EvalString(`gsh.completion.maxVisibleItems`, nil)
+	if err != nil {
+		t.Fatalf("unexpected error reading completion setting: %v", err)
+	}
+	if numVal, ok := result.FinalResult.(*NumberValue); !ok || numVal.Value <= 4 {
+		t.Fatalf("expected default completion max visible items to be greater than 4, got %v", result.FinalResult)
+	}
+
+	_, err = interp.EvalString(`gsh.completion.maxVisibleItems = 12`, nil)
+	if err != nil {
+		t.Fatalf("unexpected error setting completion max visible items: %v", err)
+	}
+	if got := interp.SDKConfig().GetCompletionMaxVisibleItems(); got != 12 {
+		t.Fatalf("expected SDK completion max visible items 12, got %d", got)
+	}
+
+	_, err = interp.EvalString(`gsh.completion.maxVisibleItems = 0`, nil)
+	if err == nil {
+		t.Fatal("expected error when setting completion max visible items below 1")
+	}
+
+	_, err = interp.EvalString(`gsh.completion.maxVisibleItems = "many"`, nil)
+	if err == nil {
+		t.Fatal("expected error when setting completion max visible items to a non-number")
+	}
+}
+
 // TestGshReplLastCommand tests that gsh.lastCommand is accessible
 func TestGshReplLastCommand(t *testing.T) {
 	interp := New(&Options{})

--- a/internal/script/interpreter/sdk.go
+++ b/internal/script/interpreter/sdk.go
@@ -148,11 +148,12 @@ func (em *EventManager) RemoveAll(eventName string) int {
 
 // SDKConfig manages runtime configuration for the SDK
 type SDKConfig struct {
-	mu               sync.RWMutex
-	logger           *zap.Logger
-	atomicLevel      zap.AtomicLevel
-	logFile          string // read-only, set at initialization
-	lastAgentRequest Value
+	mu                        sync.RWMutex
+	logger                    *zap.Logger
+	atomicLevel               zap.AtomicLevel
+	logFile                   string // read-only, set at initialization
+	lastAgentRequest          Value
+	completionMaxVisibleItems int
 	// Models holds the model tier definitions (available in both REPL and script mode)
 	models *Models
 	// REPL context (nil in script mode)
@@ -160,6 +161,8 @@ type SDKConfig struct {
 	// History provider for gsh.history access (nil in script mode)
 	historyProvider HistoryProvider
 }
+
+const DefaultCompletionMaxVisibleItems = 10
 
 // REPLContext holds REPL-specific state that's available in the SDK
 type REPLContext struct {
@@ -210,11 +213,12 @@ func NewSDKConfig(logger *zap.Logger, atomicLevel zap.AtomicLevel) *SDKConfig {
 	// It would need to be passed separately if needed in the future
 
 	return &SDKConfig{
-		logger:           logger,
-		atomicLevel:      atomicLevel,
-		logFile:          logFile,
-		lastAgentRequest: &NullValue{},
-		models:           &Models{}, // Initialize empty models (available in both REPL and script mode)
+		logger:                    logger,
+		atomicLevel:               atomicLevel,
+		logFile:                   logFile,
+		lastAgentRequest:          &NullValue{},
+		completionMaxVisibleItems: DefaultCompletionMaxVisibleItems,
+		models:                    &Models{}, // Initialize empty models (available in both REPL and script mode)
 	}
 }
 
@@ -276,6 +280,28 @@ func (sc *SDKConfig) GetLogFile() string {
 	sc.mu.RLock()
 	defer sc.mu.RUnlock()
 	return sc.logFile
+}
+
+// GetCompletionMaxVisibleItems returns the configured completion menu size.
+func (sc *SDKConfig) GetCompletionMaxVisibleItems() int {
+	sc.mu.RLock()
+	defer sc.mu.RUnlock()
+	if sc.completionMaxVisibleItems <= 0 {
+		return DefaultCompletionMaxVisibleItems
+	}
+	return sc.completionMaxVisibleItems
+}
+
+// SetCompletionMaxVisibleItems sets the completion menu size.
+func (sc *SDKConfig) SetCompletionMaxVisibleItems(value int) error {
+	if value < 1 {
+		return fmt.Errorf("completion max visible items must be at least 1")
+	}
+
+	sc.mu.Lock()
+	defer sc.mu.Unlock()
+	sc.completionMaxVisibleItems = value
+	return nil
 }
 
 // GetLastAgentRequest returns the last agent request data


### PR DESCRIPTION
## Intent

The developer wanted to inspect the latest GitHub issue and determine whether the repo could support it. The issue requested that the gsh tab-completion menu show more than four options, ideally with a configurable limit. They expected support for a larger default completion menu and a user-facing setting such as gsh.completion.maxVisibleItems, while keeping the change contained and documented. They explicitly noted that grid layout and automatic fill-screen behavior were not part of the implemented scope.

## What Changed
- Adds `gsh.completion.maxVisibleItems` as a user-configurable SDK setting with validation for integer values within the supported range.
- Updates the REPL completion menu rendering to use the configured visible item count, show more completions by default, and keep the selected completion visible while navigating.
- Documents the new completion configuration API and its validation constraints in the SDK docs.

## Risk Assessment

✅ Low: The change is narrowly scoped to a configurable completion menu size, includes targeted tests and docs, and the follow-up fix keeps the selected item visible for edge-case small windows.

## Testing

- Summary: <code>Exercised the default larger completion menu, the configured six-item menu render with scroll indication, the `gsh.completion.maxVisibleItems` SDK getter/setter validation, and the relevant input and interpreter package tests; all passed.</code>
<details>
<summary>Evidence: Rendered configured completion menu</summary>

```text
rendered completion menu with CompletionMaxVisible=6:
> item01
╭──────────────────────────────────────────────────────────────────────────────╮
│ > item01 │
│ item02 │
│ item03 │
│ item04 │
│ item05 │
│↓ 2 item06 │
╰──────────────────────────────────────────────────────────────────────────────╯
```
</details>
- Outcome: ✅ passed across 1 run (1m50s)

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

**Round 1** - passed ✅

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

**Round 1** - passed ✅

</details>

<details>
<summary>🔧 **Review** - 1 issue found → auto-fixed</summary>

**Round 1** - found 1 warning
- ⚠️ `internal/script/interpreter/sdk.go:297` - Allowing `gsh.completion.maxVisibleItems = 1` exposes an existing rendering invariant: `calculateVisibleWindow` can return a window that does not include the selected completion (for example selected index 1 with total &gt; 1), so cycling completions can show an unselected stale first item instead of the current selection. Either reject values below 2 here or adjust the window calculation to always include the selected item.

**Round 2** (auto-fix) - passed ✅

</details>

<details>
<summary>✅ **Test** - passed</summary>

**Round 1** - passed ✅
- `go test ./internal/repl/input -run 'TestCompletionMenu(ShowsMoreThanFourItemsByDefault|UsesConfiguredVisibleItemCount)$' -v`
- `go test ./internal/script/interpreter -run '^TestGshCompletionMaxVisibleItems$' -v`
- `go test ./internal/repl/input`
- `go test ./internal/script/interpreter`

</details>

<details>
<summary>🔧 **Document** - 1 issue found → auto-fixed (2)</summary>

**Round 1** - found 1 warning
- ⚠️ `docs/sdk/01-gsh-object.md:94` - The new `gsh.completion.maxVisibleItems` setting is documented only as a writable `number`, but the implementation accepts only integer values of at least 1 and rejects non-integers, zero, negatives, and excessively large values. The SDK reference should document these validation constraints so users know what values are valid.

**Round 2** (auto-fix) - found 1 warning
- ⚠️ `docs/sdk/01-gsh-object.md:96` - The `gsh.completion.maxVisibleItems` docs now mention that values must be integers of at least 1, but the setter also rejects values larger than the Go `int` maximum with `gsh.completion.maxVisibleItems is too large`. The SDK reference should document the upper-bound constraint so the documented valid range matches the public configuration API.

**Round 3** (auto-fix) - passed ✅

</details>

<details>
<summary>✅ **Lint** - passed</summary>

**Round 1** - passed ✅

</details>

<details>
<summary>✅ **Push** - passed</summary>

**Round 1** - passed ✅

</details>
